### PR TITLE
Fix the font path if sources are in the web/ folder

### DIFF
--- a/src/Widget/IconPicker.php
+++ b/src/Widget/IconPicker.php
@@ -40,6 +40,7 @@ class IconPicker extends \Widget
 
 		$fontPath = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['iconFont'];
 		$fontPathNoSuffix = implode('.', explode('.', $fontPath, -1));
+        $fontPathNoSuffix = preg_replace('/^web\//', '', $fontPathNoSuffix);
 
 		if (!file_exists(TL_ROOT . '/' . $fontPath)) {
 			return '<p class="tl_gerror"><strong>'

--- a/src/Widget/IconPicker.php
+++ b/src/Widget/IconPicker.php
@@ -40,7 +40,15 @@ class IconPicker extends \Widget
 
 		$fontPath = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['iconFont'];
 		$fontPathNoSuffix = implode('.', explode('.', $fontPath, -1));
-        $fontPathNoSuffix = preg_replace('/^web\//', '', $fontPathNoSuffix);
+
+		// Strip web directory prefix
+		if ($webDir = \System::getContainer()->getParameter('contao.web_dir')) {
+			$webDir = \StringUtil::stripRootDir($webDir);
+		}
+		else {
+			$webDir = 'web';
+		}
+		$fontPathNoSuffix = preg_replace('(^'.preg_quote($webDir).'/)', '', $fontPathNoSuffix);
 
 		if (!file_exists(TL_ROOT . '/' . $fontPath)) {
 			return '<p class="tl_gerror"><strong>'


### PR DESCRIPTION
Fix the font path if sources are in the web/ folder, e.g. in the bundles folder.

```php
'eval' => ['iconFont' => 'web/bundles/app/fonts/icomoon.svg']
```