### PR TITLE
Make icon selector position absolute

### DIFF
--- a/src/Resources/public/css/be_main.css
+++ b/src/Resources/public/css/be_main.css
@@ -20,13 +20,15 @@
 	background: #f6f6f6;
 }
 .rip_icons {
-	display: inline-block;
 	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
-	width: 100%;
-	margin-bottom: 20px;
-	padding-right: 3px;
+	position: absolute;
+	background: #FFF;
+    	z-index: 10;
+    	width: 250px;
+    	margin-left: -120px;
+    	margin-top: 42px;
 }
 .rip_icons_toolbar {
 	position: relative;


### PR DESCRIPTION
I think this would improve the usability of the icon selector:

![image](https://user-images.githubusercontent.com/1358040/120375103-adf4ce00-c31a-11eb-9e6c-1960e294de12.png)
